### PR TITLE
Rename artifacts to quarkus-minio

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -17,7 +17,7 @@
     }
   ],
   "contributorsPerLine": 7,
-  "projectName": "quarkiverse-minio",
+  "projectName": "quarkus-minio",
   "projectOwner": "quarkiverse",
   "repoType": "github",
   "repoHost": "https://github.com",

--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
-name: Quarkiverse Extension
+name: Quarkus Minio
 release:
   current-version: 0.2.0
   next-version: 0.2.1-SNAPSHOT

--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -15,7 +15,7 @@ env:
   # Repo specific setting #
   #########################
 
-  ECOSYSTEM_CI_REPO_PATH: quarkiverse-minio
+  ECOSYSTEM_CI_REPO_PATH: quarkus-minio
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Quarkus Minio Extension
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-green.svg?style=flat-square)](#contributors-)
-[![Build](https://github.com/quarkiverse/quarkiverse-minio/workflows/Build/badge.svg)](https://github.com/quarkiverse/quarkiverse-minio/actions?query=workflow%3ABuild)
-[![Maven Central](https://img.shields.io/maven-central/v/io.quarkiverse.minio/quarkiverse-minio-parent.svg?label=Maven%20Central)](https://search.maven.org/artifact/io.quarkiverse.minio/quarkiverse-minio-parent)
+[![Build](https://github.com/quarkiverse/quarkus-minio/workflows/Build/badge.svg)](https://github.com/quarkiverse/quarkus-minio/actions?query=workflow%3ABuild)
+[![Maven Central](https://img.shields.io/maven-central/v/io.quarkiverse.minio/quarkus-minio-parent.svg?label=Maven%20Central)](https://search.maven.org/artifact/io.quarkiverse.minio/quarkus-minio-parent)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
@@ -26,12 +26,12 @@ After configuring `quarkus BOM`:
 </dependencyManagement>
 ```
 
-You can just configure the `quarkiverse-minio` extension by adding the following dependency:
+You can just configure the `quarkus-minio` extension by adding the following dependency:
 
 ```xml
 <dependency>
     <groupId>io.quarkiverse.minio</groupId>
-    <artifactId>quarkiverse-minio</artifactId>
+    <artifactId>quarkus-minio</artifactId>
     <version>${latest.release.version}</version>
 </dependency>
 ```
@@ -94,7 +94,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- markdownlint-disable -->
 <table>
   <tr>
-    <td align="center"><a href="https://github.com/jtama-op"><img src="https://avatars0.githubusercontent.com/u/39991688?v=4" width="100px;" alt=""/><br /><sub><b>jtama-op</b></sub></a><br /><a href="https://github.com/quarkiverse/quarkiverse-minio/commits?author=jtama-op" title="Code">💻</a> <a href="#maintenance-jtama-op" title="Maintenance">🚧</a></td>
+    <td align="center"><a href="https://github.com/jtama-op"><img src="https://avatars0.githubusercontent.com/u/39991688?v=4" width="100px;" alt=""/><br /><sub><b>jtama-op</b></sub></a><br /><a href="https://github.com/quarkiverse/quarkus-minio/commits?author=jtama-op" title="Code">💻</a> <a href="#maintenance-jtama-op" title="Maintenance">🚧</a></td>
   </tr>
 </table>
 

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -3,13 +3,13 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.quarkiverse.minio</groupId>
-        <artifactId>quarkiverse-minio-parent</artifactId>
+        <artifactId>quarkus-minio-parent</artifactId>
         <version>0.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>quarkiverse-minio-deployment</artifactId>
-    <name>Quarkiverse Minio - Deployment</name>
+    <artifactId>quarkus-minio-deployment</artifactId>
+    <name>Quarkus Minio - Deployment</name>
 
     <dependencies>
         <dependency>
@@ -22,7 +22,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.minio</groupId>
-            <artifactId>quarkiverse-minio</artifactId>
+            <artifactId>quarkus-minio</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -4,14 +4,14 @@
 
     <parent>
         <groupId>io.quarkiverse.minio</groupId>
-        <artifactId>quarkiverse-minio-parent</artifactId>
+        <artifactId>quarkus-minio-parent</artifactId>
         <version>0.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>integration-tests</artifactId>
+    <artifactId>quarkus-minio-integration-tests</artifactId>
 
-    <name>Quarkus - Minio - Integration Tests</name>
+    <name>Quarkus Minio - Integration Tests</name>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
@@ -27,7 +27,7 @@
 
         <dependency>
             <groupId>io.quarkiverse.minio</groupId>
-            <artifactId>quarkiverse-minio</artifactId>
+            <artifactId>quarkus-minio</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,9 @@
     </parent>
 
     <groupId>io.quarkiverse.minio</groupId>
-    <artifactId>quarkiverse-minio-parent</artifactId>
+    <artifactId>quarkus-minio-parent</artifactId>
     <version>0.2.1-SNAPSHOT</version>
-    <name>Quarkiverse Minio Extension - Parent</name>
+    <name>Quarkus Minio - Parent</name>
 
     <packaging>pom</packaging>
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -3,13 +3,13 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.quarkiverse.minio</groupId>
-        <artifactId>quarkiverse-minio-parent</artifactId>
+        <artifactId>quarkus-minio-parent</artifactId>
         <version>0.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>quarkiverse-minio</artifactId>
-    <name>Quarkiverse Minio - Runtime</name>
+    <artifactId>quarkus-minio</artifactId>
+    <name>Quarkus Minio - Runtime</name>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Sorry for the disruption, we know we asked you to add the `quarkiverse-` prefix recently but, after some heated discussions, we ended up deciding we would use the `quarkus-` prefix.

See the following discussion for the new rules:
https://groups.google.com/g/quarkus-dev/c/6gNhq8Mtf0Q/m/aycmeEsQDQAJ

Here is an update to the new artifact name convention.

Could you make a new release once this is in?

Thanks!