### PR TITLE
Enhance client creation - add `quarkus.minio.allow-empty` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,13 @@ public class SampleService {
 
 Configuration is done through standard application.properties mechanism. 
 Configuration is optional, but if present url has to be a valid http url.
+If allow-empty is set to `true` and all other configuration options are empty, `null` is produced instead of the minio client.
 
 ```properties
 quarkus.minio.url=https://minio.acme
 quarkus.minio.access-key=DUMMY-ACCESS-KEY
 quarkus.minio.secret-key=DUMMY-SECRET-KEY
+quarkus.minio.allow-empty=true/false (Boolean type, default value is false)
 ```
 
 ## Contributors ✨

--- a/deployment/src/test/java/io/quarkiverse/minio/client/MinioAllowEmptyAndInvalidUrlTest.java
+++ b/deployment/src/test/java/io/quarkiverse/minio/client/MinioAllowEmptyAndInvalidUrlTest.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.minio.client;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.minio.MinioClient;
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusUnitTest;
+
+class MinioAllowEmptyAndInvalidUrlTest {
+
+    @Inject
+    Instance<MinioClient> minioClient;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-allow-empty-and-invalid-url.properties");
+
+    @Test
+    public void invalidUrlThrowsException() {
+        //Not validating other configuration keys as quarkus already does it for us.
+        // toString method only here to trigger client instanciation
+        Assertions.assertThatThrownBy(() -> minioClient.get().toString())
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageStartingWith("\"quarkus.minio.url\" is mandatory");
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/minio/client/MinioAllowEmptyAndValidTest.java
+++ b/deployment/src/test/java/io/quarkiverse/minio/client/MinioAllowEmptyAndValidTest.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.minio.client;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.minio.MinioClient;
+import io.quarkus.test.QuarkusUnitTest;
+
+class MinioAllowEmptyAndValidTest {
+
+    @Inject
+    MinioClient minioClient;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-allow-empty-and-valid.properties");
+
+    @Test
+    public void testDefaultDataSourceInjection() {
+        assertThatCode(() -> minioClient.toString()).doesNotThrowAnyException();
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/minio/client/MinioAllowEmptyTest.java
+++ b/deployment/src/test/java/io/quarkiverse/minio/client/MinioAllowEmptyTest.java
@@ -1,0 +1,27 @@
+package io.quarkiverse.minio.client;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.minio.MinioClient;
+import io.quarkus.test.QuarkusUnitTest;
+
+class MinioAllowEmptyTest {
+
+    @Inject
+    Instance<MinioClient> minioClient;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-allow-empty.properties");
+
+    @Test
+    public void testDefaultDataSourceInjection() {
+        MinioClient mc = minioClient.get();
+        Assertions.assertThat(mc == null);
+    }
+}

--- a/deployment/src/test/resources/application-allow-empty-and-invalid-url.properties
+++ b/deployment/src/test/resources/application-allow-empty-and-invalid-url.properties
@@ -1,0 +1,4 @@
+quarkus.minio.url=minio
+quarkus.minio.access-key=access-key
+quarkus.minio.secret-key=secret-key
+quarkus.minio.allow-empty=true

--- a/deployment/src/test/resources/application-allow-empty-and-valid.properties
+++ b/deployment/src/test/resources/application-allow-empty-and-valid.properties
@@ -1,0 +1,4 @@
+quarkus.minio.url=http://minio
+quarkus.minio.access-key=access-key
+quarkus.minio.secret-key=secret-key
+quarkus.minio.allow-empty=true

--- a/deployment/src/test/resources/application-allow-empty.properties
+++ b/deployment/src/test/resources/application-allow-empty.properties
@@ -1,0 +1,1 @@
+quarkus.minio.allow-empty=true

--- a/runtime/src/main/java/io/quarkiverse/minio/client/MinioConfiguration.java
+++ b/runtime/src/main/java/io/quarkiverse/minio/client/MinioConfiguration.java
@@ -38,6 +38,15 @@ public class MinioConfiguration {
     @ConfigItem
     Optional<String> secretKey;
 
+    /**
+     * If value is false (default) or some of other properties is present, then producer behaves as this option is not set.
+     * If value is true and and all other configuration options are empty, producer returns null as a client.
+     *
+     * @asciidoclet
+     */
+    @ConfigItem
+    Optional<Boolean> allowEmpty;
+
     public String getUrl() {
         return url.orElse("");
     }
@@ -48,5 +57,9 @@ public class MinioConfiguration {
 
     String getSecretKey() {
         return secretKey.orElse("");
+    }
+
+    boolean returnEmptyClient() {
+        return allowEmpty.orElse(false) && !url.isPresent() && !accessKey.isPresent() && !secretKey.isPresent();
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/minio/client/MinioProducer.java
+++ b/runtime/src/main/java/io/quarkiverse/minio/client/MinioProducer.java
@@ -2,6 +2,7 @@ package io.quarkiverse.minio.client;
 
 import java.util.function.Predicate;
 
+import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -19,8 +20,11 @@ public class MinioProducer {
             || value.startsWith("https://"));
 
     @Produces
-    @Singleton
+    @Dependent
     public MinioClient produceMinioClient() {
+        if (configuration.returnEmptyClient()) {
+            return null;
+        }
         verifyUrl();
         return MinioClient.builder()
                 .endpoint(configuration.getUrl())


### PR DESCRIPTION
fixes https://github.com/quarkiverse/quarkus-minio/issues/64

PR adds property `quarkus.minio.allowEmpty` + junit test + doc update.


 If `quarkus.minio.allowEmpty` is set to `true` and `quarkus.minio.url` is not valid, producer returns `null` instead of throwing `ConfigurationException`. 

@jtama I changed scope of the client to be `@Dependent`, because it could return `null`.

Default behavior is not changed.


