### PR TITLE
Upgrade to Quarkus 2.0.0.Final

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,4 @@
 name: Quarkus Minio
 release:
-  current-version: 0.2.3
-  next-version: 0.2.4-SNAPSHOT
-
+  current-version: 2.0.0
+  next-version: 2.0.1-SNAPSHOT

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>1.13.7.Final</quarkus.version>
+        <quarkus.version>2.0.0.Final</quarkus.version>
         <minio.version>8.2.2</minio.version>
     </properties>
 


### PR DESCRIPTION
@jtama this is a reminder rather than real PR, because I am frankly not sure whether this is correct and whether the change shouldn't go to your 2.x branch. In any case we'd appreciate a Quarkus 2.0.0.Final based release (with the recent fix of @JiriOndrusek 68c59f1b084b5409173ea8134ce809b8d01df376 included) soon.