### PR TITLE
fix: doc version attribute bump from 2.10.2 to 2.10.3

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,1 +1,1 @@
-:quarkus-minio-version: 2.10.2
+:quarkus-minio-version: 2.10.3


### PR DESCRIPTION
[skip ci]