### PR TITLE
Allow testcontainers shared network

### DIFF
--- a/minio-client/deployment/src/main/resources/dev-templates/embedded.html
+++ b/minio-client/deployment/src/main/resources/dev-templates/embedded.html
@@ -1,9 +1,11 @@
-{#if config:property('quarkus.minio.devservices.enabled') != 'false' && config:property('quarkus.minio.console')}
+{#if config:property('quarkus.minio.devservices.enabled') != 'false'}
+{#if config:property('quarkus.minio.console')}
 <a href="{config:property('quarkus.minio.console')}" class="badge badge-light">
     <i class="fa fa-map-signs fa-fw"></i>
     Min.io console
 </a>
 <br>
+{/if}
 <span class="badge badge-light">AccessKey : {config:property('quarkus.minio.access-key')}</span><br>
 <span class="badge badge-light">SecretKey : {config:property('quarkus.minio.secret-key')}</span><br>
 {/if}


### PR DESCRIPTION
Fix #226

I have kept the host-exposed URL for the console as I believe it is initially intended to be accessible by the user.

I am setting the groundwork for the console to be optional in the future. I didn't like the idea of having a wrong url displayed to the user in the dev ui when using an existing container.