### PR TITLE
Limit uri tag values.

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,2 +1,2 @@
-:quarkus-version: 3.3.1
+:quarkus-version: 3.3.2
 :quarkus-minio-version: 3.3.1

--- a/docs/modules/ROOT/pages/includes/quarkus-minio.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-minio.adoc
@@ -162,7 +162,7 @@ a| [[quarkus-minio_quarkus.minio.produce-metrics]]`link:#quarkus-minio_quarkus.m
 If value is `true` (default) and the `io.quarkus.quarkus-micrometer` is present in the class path,
 then the minio client will produce metrics.
 
-Value is set for minio clients produced.
+Only true for clients produced by the extension
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO_PRODUCE_METRICS+++[]
@@ -171,7 +171,24 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_MINIO_PRODUCE_METRICS+++`
 endif::add-copy-button-to-env-var[]
 --|boolean 
-|
+|`true`
+
+
+a| [[quarkus-minio_quarkus.minio.maximum-allowed-tag]]`link:#quarkus-minio_quarkus.minio.maximum-allowed-tag[quarkus.minio.maximum-allowed-tag]`
+
+
+[.description]
+--
+If minio clients are to produce metrics, then the uri tag will have a max of 100 values
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO_MAXIMUM_ALLOWED_TAG+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MINIO_MAXIMUM_ALLOWED_TAG+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`100`
 
 
 a| [[quarkus-minio_quarkus.minio.url]]`link:#quarkus-minio_quarkus.minio.url[quarkus.minio.url]`

--- a/minio-client/runtime/src/main/java/io/quarkiverse/minio/client/MinioClients.java
+++ b/minio-client/runtime/src/main/java/io/quarkiverse/minio/client/MinioClients.java
@@ -71,7 +71,7 @@ public class MinioClients {
                 .endpoint(configuration.getUrl())
                 .credentials(configuration.getAccessKey(), configuration.getSecretKey());
         configuration.region.ifPresent(builder::region);
-        if (miniosRuntimeConfiguration.produceMetrics()) {
+        if (miniosRuntimeConfiguration.produceMetrics) {
             httpClientProducer.apply(minioClientName).ifPresent(builder::httpClient);
         }
         return builder.build();

--- a/minio-client/runtime/src/main/java/io/quarkiverse/minio/client/MiniosRuntimeConfiguration.java
+++ b/minio-client/runtime/src/main/java/io/quarkiverse/minio/client/MiniosRuntimeConfiguration.java
@@ -1,7 +1,6 @@
 package io.quarkiverse.minio.client;
 
 import java.util.Map;
-import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -14,12 +13,18 @@ public class MiniosRuntimeConfiguration {
      * If value is `true` (default) and the `io.quarkus.quarkus-micrometer` is present in the class path,
      * then the minio client will produce metrics.
      *
-     * Value is set for minio clients produced.
+     * Only true for clients produced by the extension
      *
      * @asciidoclet
      */
-    @ConfigItem
-    public Optional<Boolean> produceMetrics;
+    @ConfigItem(defaultValue = "true")
+    public boolean produceMetrics;
+
+    /**
+     * If minio clients are to produce metrics, then the uri tag will have a max of 100 values
+     */
+    @ConfigItem(defaultValue = "100")
+    public Integer maximumAllowedTag;
 
     /**
      * The default client
@@ -39,9 +44,5 @@ public class MiniosRuntimeConfiguration {
 
     public Map<String, MinioRuntimeConfiguration> namedMinioClients() {
         return namedMinioClients;
-    }
-
-    boolean produceMetrics() {
-        return produceMetrics.orElse(true);
     }
 }


### PR DESCRIPTION
Maximum tag values can be configured via `quarkus.minio.maximum-allowed-tag`, defaults to 100.