### PR TITLE
Release 3.7.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus Minio
 release:
-  current-version: 3.3.1
-  next-version: 3.3.2-SNAPSHOT
+  current-version: 3.7.0
+  next-version: 3.7.1-SNAPSHOT

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,2 +1,2 @@
-:quarkus-version: 3.3.2
-:quarkus-minio-version: 3.3.1
+:quarkus-version: 3.7.0
+:quarkus-minio-version: 3.7.0


### PR DESCRIPTION
Release 3.7.0

Fixes micrometer memory leaks.
Bumps quarkus version to 3.7.0.
Bumps minio sdk to 8.5.7. 