### PR TITLE
Minio Client Extension to Support Flexible Endpoint, Port, and TLS Configurations

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,2 +1,2 @@
-:quarkus-version: 3.7.0
+:quarkus-version: 3.8.2
 :quarkus-minio-version: 3.7.1

--- a/docs/modules/ROOT/pages/includes/quarkus-minio.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-minio.adoc
@@ -10,7 +10,7 @@ h|[[quarkus-minio_configuration]]link:#quarkus-minio_configuration[Configuration
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus.minio.devservices.enabled]]`link:#quarkus-minio_quarkus.minio.devservices.enabled[quarkus.minio.devservices.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minio-devservices-enabled]]`link:#quarkus-minio_quarkus-minio-devservices-enabled[quarkus.minio.devservices.enabled]`
 
 
 [.description]
@@ -27,7 +27,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus.minio.devservices.port]]`link:#quarkus-minio_quarkus.minio.devservices.port[quarkus.minio.devservices.port]`
+a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minio-devservices-port]]`link:#quarkus-minio_quarkus-minio-devservices-port[quarkus.minio.devservices.port]`
 
 
 [.description]
@@ -46,7 +46,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus.minio.devservices.image-name]]`link:#quarkus-minio_quarkus.minio.devservices.image-name[quarkus.minio.devservices.image-name]`
+a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minio-devservices-image-name]]`link:#quarkus-minio_quarkus-minio-devservices-image-name[quarkus.minio.devservices.image-name]`
 
 
 [.description]
@@ -63,7 +63,7 @@ endif::add-copy-button-to-env-var[]
 |`minio/minio:RELEASE.2022-10-08T20-11-00Z`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus.minio.devservices.shared]]`link:#quarkus-minio_quarkus.minio.devservices.shared[quarkus.minio.devservices.shared]`
+a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minio-devservices-shared]]`link:#quarkus-minio_quarkus-minio-devservices-shared[quarkus.minio.devservices.shared]`
 
 
 [.description]
@@ -84,7 +84,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus.minio.devservices.service-name]]`link:#quarkus-minio_quarkus.minio.devservices.service-name[quarkus.minio.devservices.service-name]`
+a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minio-devservices-service-name]]`link:#quarkus-minio_quarkus-minio-devservices-service-name[quarkus.minio.devservices.service-name]`
 
 
 [.description]
@@ -103,7 +103,7 @@ endif::add-copy-button-to-env-var[]
 |`minio`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus.minio.devservices.access-key]]`link:#quarkus-minio_quarkus.minio.devservices.access-key[quarkus.minio.devservices.access-key]`
+a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minio-devservices-access-key]]`link:#quarkus-minio_quarkus-minio-devservices-access-key[quarkus.minio.devservices.access-key]`
 
 
 [.description]
@@ -120,7 +120,7 @@ endif::add-copy-button-to-env-var[]
 |`minioaccess`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus.minio.devservices.secret-key]]`link:#quarkus-minio_quarkus.minio.devservices.secret-key[quarkus.minio.devservices.secret-key]`
+a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minio-devservices-secret-key]]`link:#quarkus-minio_quarkus-minio-devservices-secret-key[quarkus.minio.devservices.secret-key]`
 
 
 [.description]
@@ -137,7 +137,7 @@ endif::add-copy-button-to-env-var[]
 |`miniosecret`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus.minio.enabled]]`link:#quarkus-minio_quarkus.minio.enabled[quarkus.minio.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minio-enabled]]`link:#quarkus-minio_quarkus-minio-enabled[quarkus.minio.enabled]`
 
 
 [.description]
@@ -154,7 +154,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-minio_quarkus.minio.produce-metrics]]`link:#quarkus-minio_quarkus.minio.produce-metrics[quarkus.minio.produce-metrics]`
+a| [[quarkus-minio_quarkus-minio-produce-metrics]]`link:#quarkus-minio_quarkus-minio-produce-metrics[quarkus.minio.produce-metrics]`
 
 
 [.description]
@@ -174,7 +174,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-minio_quarkus.minio.maximum-allowed-tag]]`link:#quarkus-minio_quarkus.minio.maximum-allowed-tag[quarkus.minio.maximum-allowed-tag]`
+a| [[quarkus-minio_quarkus-minio-maximum-allowed-tag]]`link:#quarkus-minio_quarkus-minio-maximum-allowed-tag[quarkus.minio.maximum-allowed-tag]`
 
 
 [.description]
@@ -191,17 +191,12 @@ endif::add-copy-button-to-env-var[]
 |`100`
 
 
-a| [[quarkus-minio_quarkus.minio.url]]`link:#quarkus-minio_quarkus.minio.url[quarkus.minio.url]`
+a| [[quarkus-minio_quarkus-minio-url]]`link:#quarkus-minio_quarkus-minio-url[quarkus.minio.url]`
 
 
 [.description]
 --
 The minio server URL.
-
-[NOTE]
-====
-Value must start with `http://` or `https://`
-====
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO_URL+++[]
@@ -213,7 +208,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-minio_quarkus.minio.access-key]]`link:#quarkus-minio_quarkus.minio.access-key[quarkus.minio.access-key]`
+a| [[quarkus-minio_quarkus-minio-access-key]]`link:#quarkus-minio_quarkus-minio-access-key[quarkus.minio.access-key]`
 
 
 [.description]
@@ -230,7 +225,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-minio_quarkus.minio.secret-key]]`link:#quarkus-minio_quarkus.minio.secret-key[quarkus.minio.secret-key]`
+a| [[quarkus-minio_quarkus-minio-secret-key]]`link:#quarkus-minio_quarkus-minio-secret-key[quarkus.minio.secret-key]`
 
 
 [.description]
@@ -247,7 +242,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-minio_quarkus.minio.region]]`link:#quarkus-minio_quarkus.minio.region[quarkus.minio.region]`
+a| [[quarkus-minio_quarkus-minio-region]]`link:#quarkus-minio_quarkus-minio-region[quarkus.minio.region]`
 
 
 [.description]
@@ -264,7 +259,41 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus.minio.-named-minio-clients-.enabled]]`link:#quarkus-minio_quarkus.minio.-named-minio-clients-.enabled[quarkus.minio."named-minio-clients".enabled]`
+a| [[quarkus-minio_quarkus-minio-port]]`link:#quarkus-minio_quarkus-minio-port[quarkus.minio.port]`
+
+
+[.description]
+--
+An optional port number
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MINIO_PORT+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|
+
+
+a| [[quarkus-minio_quarkus-minio-secure]]`link:#quarkus-minio_quarkus-minio-secure[quarkus.minio.secure]`
+
+
+[.description]
+--
+An optional boolean to enable secure connection
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO_SECURE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MINIO_SECURE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minio-named-minio-clients-enabled]]`link:#quarkus-minio_quarkus-minio-named-minio-clients-enabled[quarkus.minio."named-minio-clients".enabled]`
 
 
 [.description]
@@ -281,17 +310,12 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-minio_quarkus.minio.-named-minio-clients-.url]]`link:#quarkus-minio_quarkus.minio.-named-minio-clients-.url[quarkus.minio."named-minio-clients".url]`
+a| [[quarkus-minio_quarkus-minio-named-minio-clients-url]]`link:#quarkus-minio_quarkus-minio-named-minio-clients-url[quarkus.minio."named-minio-clients".url]`
 
 
 [.description]
 --
 The minio server URL.
-
-[NOTE]
-====
-Value must start with `http://` or `https://`
-====
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO__NAMED_MINIO_CLIENTS__URL+++[]
@@ -303,7 +327,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-minio_quarkus.minio.-named-minio-clients-.access-key]]`link:#quarkus-minio_quarkus.minio.-named-minio-clients-.access-key[quarkus.minio."named-minio-clients".access-key]`
+a| [[quarkus-minio_quarkus-minio-named-minio-clients-access-key]]`link:#quarkus-minio_quarkus-minio-named-minio-clients-access-key[quarkus.minio."named-minio-clients".access-key]`
 
 
 [.description]
@@ -320,7 +344,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-minio_quarkus.minio.-named-minio-clients-.secret-key]]`link:#quarkus-minio_quarkus.minio.-named-minio-clients-.secret-key[quarkus.minio."named-minio-clients".secret-key]`
+a| [[quarkus-minio_quarkus-minio-named-minio-clients-secret-key]]`link:#quarkus-minio_quarkus-minio-named-minio-clients-secret-key[quarkus.minio."named-minio-clients".secret-key]`
 
 
 [.description]
@@ -337,7 +361,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-minio_quarkus.minio.-named-minio-clients-.region]]`link:#quarkus-minio_quarkus.minio.-named-minio-clients-.region[quarkus.minio."named-minio-clients".region]`
+a| [[quarkus-minio_quarkus-minio-named-minio-clients-region]]`link:#quarkus-minio_quarkus-minio-named-minio-clients-region[quarkus.minio."named-minio-clients".region]`
 
 
 [.description]
@@ -351,6 +375,40 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_MINIO__NAMED_MINIO_CLIENTS__REGION+++`
 endif::add-copy-button-to-env-var[]
 --|string 
+|
+
+
+a| [[quarkus-minio_quarkus-minio-named-minio-clients-port]]`link:#quarkus-minio_quarkus-minio-named-minio-clients-port[quarkus.minio."named-minio-clients".port]`
+
+
+[.description]
+--
+An optional port number
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO__NAMED_MINIO_CLIENTS__PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MINIO__NAMED_MINIO_CLIENTS__PORT+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|
+
+
+a| [[quarkus-minio_quarkus-minio-named-minio-clients-secure]]`link:#quarkus-minio_quarkus-minio-named-minio-clients-secure[quarkus.minio."named-minio-clients".secure]`
+
+
+[.description]
+--
+An optional boolean to enable secure connection
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO__NAMED_MINIO_CLIENTS__SECURE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MINIO__NAMED_MINIO_CLIENTS__SECURE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
 |
 
 |===

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -92,17 +92,23 @@ each with its own configuration.
 
 [source,properties]
 ----
-quarkus.minio.url=http://localhost:9000
+quarkus.minio.url=http://localhost
+quarkus.minio.port=9000
+quarkus.minio.tls=false
 quarkus.minio.access-key=minioaccess
 quarkus.minio.secret-key=miniosecret
 
 quarkus.minio.other.enabled=true
-quarkus.minio.other.url=http://acme:9000
+quarkus.minio.other.url=http://acme
+quarkus.minio.port=9000
+quarkus.minio.tls=false
 quarkus.minio.other.access-key=minioaccess
 quarkus.minio.other.secret-key=miniosecret
 
 quarkus.minio.public.enabled=true
-quarkus.minio.public.url=http://public:9000
+quarkus.minio.public.url=http://public
+quarkus.minio.port=9000
+quarkus.minio.tls=false
 quarkus.minio.public.access-key=minioaccess
 quarkus.minio.public.secret-key=miniosecret
 ----

--- a/minio-client/deployment/src/main/java/io/quarkiverse/minio/client/deployment/devservices/DevServicesMinioProcessor.java
+++ b/minio-client/deployment/src/main/java/io/quarkiverse/minio/client/deployment/devservices/DevServicesMinioProcessor.java
@@ -232,7 +232,8 @@ public class DevServicesMinioProcessor {
                 .ifPresent(consolePort -> result.put(MINIO_CONSOLE, String.format("http://%s:%d", consoleHost, consolePort)));
 
         buildTimeConfiguration.getMinioClients().entrySet().stream()
-                .map(entry -> Map.of(formatPropertyName(MINIO_URL, entry.getKey()), String.format("http://%s:%d", host, port),
+                .map(entry -> Map.of(formatPropertyName(MINIO_URL, entry.getKey()), String.format("http://%s", host),
+                        formatPropertyName(String.valueOf(MINIO_PORT), entry.getKey()), config.port.toString(),
                         formatPropertyName(MINIO_ACCESS_KEY, entry.getKey()), config.accessKey,
                         formatPropertyName(MINIO_SECRET_KEY, entry.getKey()), config.secretKey))
                 .forEach(result::putAll);
@@ -264,6 +265,8 @@ public class DevServicesMinioProcessor {
         private final String serviceName;
         private final String accessKey;
         private final String secretKey;
+        private final boolean tls = false;
+        private final Integer port;
 
         public MinioDevServiceCfg(MinioDevServicesBuildTimeConfig config) {
             this.devServicesEnabled = config.enabled.orElse(true);
@@ -273,6 +276,7 @@ public class DevServicesMinioProcessor {
             this.serviceName = config.serviceName;
             this.accessKey = config.accessKey;
             this.secretKey = config.secretKey;
+            this.port = config.port.orElse(9000);
         }
 
         @Override

--- a/minio-client/deployment/src/test/resources/application-invalid-url.properties
+++ b/minio-client/deployment/src/test/resources/application-invalid-url.properties
@@ -1,4 +1,3 @@
 quarkus.minio.devservices.enabled=false
-quarkus.minio.url=minio
 quarkus.minio.access-key=access-key
 quarkus.minio.secret-key=secret-key

--- a/minio-client/deployment/src/test/resources/application-named-invalid-url.properties
+++ b/minio-client/deployment/src/test/resources/application-named-invalid-url.properties
@@ -1,5 +1,4 @@
 quarkus.minio.devservices.enabled=false
 quarkus.minio.acme.enabled=true
-quarkus.minio.acme.url=minio
 quarkus.minio.acme.access-key=access-key
 quarkus.minio.acme.secret-key=secret-key

--- a/minio-client/deployment/src/test/resources/application-one-invalid-url-the-other-valid.properties
+++ b/minio-client/deployment/src/test/resources/application-one-invalid-url-the-other-valid.properties
@@ -1,5 +1,4 @@
 quarkus.minio.devservices.enabled=false
-quarkus.minio.url=minio
 quarkus.minio.access-key=access-key
 quarkus.minio.secret-key=secret-key
 quarkus.minio.another.url=http://minio

--- a/minio-client/runtime/src/main/java/io/quarkiverse/minio/client/MinioRuntimeConfiguration.java
+++ b/minio-client/runtime/src/main/java/io/quarkiverse/minio/client/MinioRuntimeConfiguration.java
@@ -11,11 +11,6 @@ public class MinioRuntimeConfiguration {
     /**
      * The minio server URL.
      *
-     * [NOTE]
-     * ====
-     * Value must start with `http://` or `https://`
-     * ====
-     *
      * @asciidoclet
      */
     @ConfigItem
@@ -45,6 +40,22 @@ public class MinioRuntimeConfiguration {
     @ConfigItem
     Optional<String> region = Optional.empty();
 
+    /**
+     * An optional port number
+     *
+     * @asciidoclet
+     */
+    @ConfigItem
+    Optional<Integer> port = Optional.empty();
+
+    /**
+     * An optional boolean to enable secure connection
+     *
+     * @asciidoclet
+     */
+    @ConfigItem
+    Optional<Boolean> secure = Optional.empty();
+
     public String getUrl() {
         return url.orElse("");
     }
@@ -55,5 +66,13 @@ public class MinioRuntimeConfiguration {
 
     String getSecretKey() {
         return secretKey.orElse("");
+    }
+
+    Integer getPort() {
+        return port.orElse(9000);
+    }
+
+    Boolean isTls() {
+        return secure.orElse(true);
     }
 }


### PR DESCRIPTION
This PR introduces targeted enhancements to the `quarkiverse-minio` extension, aimed at increasing its flexibility by allowing users to specify MinIO endpoints without requiring explicit "http://" or "https://" prefixes, configure custom port numbers, and toggle TLS security. By default, the extension now assumes port 443 for connections and enables TLS, aligning with common MinIO deployment practices. These changes facilitate easier integration with MinIO services, accommodating a variety of network and security configurations.

#### Changes

1. **Simplified Endpoint Configuration**: Updated `MinioRuntimeConfiguration` to gracefully handle MinIO server URLs without the need for "http://" or "https://" prefixes, simplifying configuration files.
2. **Custom Port and TLS Toggle**: Introduced optional configurations for custom port numbers and a TLS toggle. This enhancement allows developers to easily switch between standard and custom ports and choose between secure (TLS) and non-secure connections based on their deployment requirements.
3. **Default Settings for Port and TLS**: Set default values for the port (443) and TLS (enabled) to ensure out-of-the-box security and compatibility with standard MinIO server deployments.

#### Motivation

The primary motivation for these updates is to provide Quarkus developers with a more adaptable and user-friendly way to configure MinIO client connections, catering to the diverse setups found in real-world applications. These enhancements are a step towards supporting the comprehensive set of use cases documented in the MinIO Java Client API, making the extension more versatile.

#### Next Steps

While this PR addresses specific aspects of MinIO client configuration, future enhancements should aim to support the full spectrum of use cases outlined in the [MinIO Java Client API documentation](https://min.io/docs/minio/linux/developers/java/API.html). This includes anonymous access, authenticated access with different security mechanisms, region specification, and the use of custom HTTP clients. Planning and implementing these features will further solidify the `quarkiverse-minio` extension as a robust and comprehensive solution for MinIO integration in Quarkus applications.

#### How to Test

1. Configure your `application.properties` to connect to a MinIO server, specifying the endpoint without the "http://" or "https://" prefix, and adjust the port and TLS settings as needed.
2. Deploy your Quarkus application and ensure it can successfully communicate with the specified MinIO server.

#### Documentation

The documentation has been updated to reflect these new configuration options, offering guidance on how to leverage the simplified endpoint configuration, custom port numbers, and TLS settings.
