### PR TITLE
Provide MinioAsyncClient instances same as MinioClient

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-minio.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-minio.adoc
@@ -154,6 +154,151 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
+a| [[quarkus-minio_quarkus-minio-produce-metrics]]`link:#quarkus-minio_quarkus-minio-produce-metrics[quarkus.minio.produce-metrics]`
+
+
+[.description]
+--
+If value is `true` (default) and the `io.quarkus.quarkus-micrometer` is present in the class path,
+then the minio client will produce metrics.
+
+Only true for clients produced by the extension
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO_PRODUCE_METRICS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MINIO_PRODUCE_METRICS+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`true`
+
+
+a| [[quarkus-minio_quarkus-minio-maximum-allowed-tag]]`link:#quarkus-minio_quarkus-minio-maximum-allowed-tag[quarkus.minio.maximum-allowed-tag]`
+
+
+[.description]
+--
+If minio clients are to produce metrics, then the uri tag will have a max of 100 values
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO_MAXIMUM_ALLOWED_TAG+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MINIO_MAXIMUM_ALLOWED_TAG+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`100`
+
+
+a| [[quarkus-minio_quarkus-minio-url]]`link:#quarkus-minio_quarkus-minio-url[quarkus.minio.url]`
+
+
+[.description]
+--
+The minio server URL.
+The url _may_ contains the port, though it's not recommended. If a specific port is needed, `quakus.minio.port` is a
+better fit.
+<p>
+[NOTE]
+====
+Value must start with `http://` or `https://`
+====
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO_URL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MINIO_URL+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-minio_quarkus-minio-access-key]]`link:#quarkus-minio_quarkus-minio-access-key[quarkus.minio.access-key]`
+
+
+[.description]
+--
+The minio server access key
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO_ACCESS_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MINIO_ACCESS_KEY+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-minio_quarkus-minio-secret-key]]`link:#quarkus-minio_quarkus-minio-secret-key[quarkus.minio.secret-key]`
+
+
+[.description]
+--
+The minio server secret key
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO_SECRET_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MINIO_SECRET_KEY+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-minio_quarkus-minio-region]]`link:#quarkus-minio_quarkus-minio-region[quarkus.minio.region]`
+
+
+[.description]
+--
+An optional bucket region
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO_REGION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MINIO_REGION+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-minio_quarkus-minio-port]]`link:#quarkus-minio_quarkus-minio-port[quarkus.minio.port]`
+
+
+[.description]
+--
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MINIO_PORT+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|
+
+
+a| [[quarkus-minio_quarkus-minio-secure]]`link:#quarkus-minio_quarkus-minio-secure[quarkus.minio.secure]`
+
+
+[.description]
+--
+An optional boolean to enable secure connection.
+Defaults to `true`
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO_SECURE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MINIO_SECURE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`true`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minio-devservices-container-env-environment-variable-name]]`link:#quarkus-minio_quarkus-minio-devservices-container-env-environment-variable-name[quarkus.minio.devservices.container-env."environment-variable-name"]`
 
 
@@ -189,44 +334,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minios-runtime-produce-metrics]]`link:#quarkus-minio_quarkus-minios-runtime-produce-metrics[quarkus.minios-runtime.produce-metrics]`
-
-
-[.description]
---
-If value is `true` (default) and the `io.quarkus.quarkus-micrometer` is present in the class path,
-then the minio client will produce metrics.
-
-Only true for clients produced by the extension
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MINIOS_RUNTIME_PRODUCE_METRICS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MINIOS_RUNTIME_PRODUCE_METRICS+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|`false`
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minios-runtime-maximum-allowed-tag]]`link:#quarkus-minio_quarkus-minios-runtime-maximum-allowed-tag[quarkus.minios-runtime.maximum-allowed-tag]`
-
-
-[.description]
---
-If minio clients are to produce metrics, then the uri tag will have a max of 100 values
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MINIOS_RUNTIME_MAXIMUM_ALLOWED_TAG+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MINIOS_RUNTIME_MAXIMUM_ALLOWED_TAG+++`
-endif::add-copy-button-to-env-var[]
---|int 
-|required icon:exclamation-circle[title=Configuration property is required]
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minios-runtime-minio-url]]`link:#quarkus-minio_quarkus-minios-runtime-minio-url[quarkus.minios-runtime.minio.url]`
+a| [[quarkus-minio_quarkus-minio-named-minio-clients-url]]`link:#quarkus-minio_quarkus-minio-named-minio-clients-url[quarkus.minio."named-minio-clients".url]`
 
 
 [.description]
@@ -241,16 +349,16 @@ Value must start with `http://` or `https://`
 ====
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MINIOS_RUNTIME_MINIO_URL+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO__NAMED_MINIO_CLIENTS__URL+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MINIOS_RUNTIME_MINIO_URL+++`
+Environment variable: `+++QUARKUS_MINIO__NAMED_MINIO_CLIENTS__URL+++`
 endif::add-copy-button-to-env-var[]
 --|string 
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minios-runtime-minio-access-key]]`link:#quarkus-minio_quarkus-minios-runtime-minio-access-key[quarkus.minios-runtime.minio.access-key]`
+a| [[quarkus-minio_quarkus-minio-named-minio-clients-access-key]]`link:#quarkus-minio_quarkus-minio-named-minio-clients-access-key[quarkus.minio."named-minio-clients".access-key]`
 
 
 [.description]
@@ -258,16 +366,16 @@ a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minios-runtime-mi
 The minio server access key
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MINIOS_RUNTIME_MINIO_ACCESS_KEY+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO__NAMED_MINIO_CLIENTS__ACCESS_KEY+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MINIOS_RUNTIME_MINIO_ACCESS_KEY+++`
+Environment variable: `+++QUARKUS_MINIO__NAMED_MINIO_CLIENTS__ACCESS_KEY+++`
 endif::add-copy-button-to-env-var[]
 --|string 
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minios-runtime-minio-secret-key]]`link:#quarkus-minio_quarkus-minios-runtime-minio-secret-key[quarkus.minios-runtime.minio.secret-key]`
+a| [[quarkus-minio_quarkus-minio-named-minio-clients-secret-key]]`link:#quarkus-minio_quarkus-minio-named-minio-clients-secret-key[quarkus.minio."named-minio-clients".secret-key]`
 
 
 [.description]
@@ -275,16 +383,16 @@ a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minios-runtime-mi
 The minio server secret key
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MINIOS_RUNTIME_MINIO_SECRET_KEY+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO__NAMED_MINIO_CLIENTS__SECRET_KEY+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MINIOS_RUNTIME_MINIO_SECRET_KEY+++`
+Environment variable: `+++QUARKUS_MINIO__NAMED_MINIO_CLIENTS__SECRET_KEY+++`
 endif::add-copy-button-to-env-var[]
 --|string 
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minios-runtime-minio-region]]`link:#quarkus-minio_quarkus-minios-runtime-minio-region[quarkus.minios-runtime.minio.region]`
+a| [[quarkus-minio_quarkus-minio-named-minio-clients-region]]`link:#quarkus-minio_quarkus-minio-named-minio-clients-region[quarkus.minio."named-minio-clients".region]`
 
 
 [.description]
@@ -292,31 +400,31 @@ a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minios-runtime-mi
 An optional bucket region
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MINIOS_RUNTIME_MINIO_REGION+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO__NAMED_MINIO_CLIENTS__REGION+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MINIOS_RUNTIME_MINIO_REGION+++`
+Environment variable: `+++QUARKUS_MINIO__NAMED_MINIO_CLIENTS__REGION+++`
 endif::add-copy-button-to-env-var[]
 --|string 
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minios-runtime-minio-port]]`link:#quarkus-minio_quarkus-minios-runtime-minio-port[quarkus.minios-runtime.minio.port]`
+a| [[quarkus-minio_quarkus-minio-named-minio-clients-port]]`link:#quarkus-minio_quarkus-minio-named-minio-clients-port[quarkus.minio."named-minio-clients".port]`
 
 
 [.description]
 --
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MINIOS_RUNTIME_MINIO_PORT+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO__NAMED_MINIO_CLIENTS__PORT+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MINIOS_RUNTIME_MINIO_PORT+++`
+Environment variable: `+++QUARKUS_MINIO__NAMED_MINIO_CLIENTS__PORT+++`
 endif::add-copy-button-to-env-var[]
 --|int 
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minios-runtime-minio-secure]]`link:#quarkus-minio_quarkus-minios-runtime-minio-secure[quarkus.minios-runtime.minio.secure]`
+a| [[quarkus-minio_quarkus-minio-named-minio-clients-secure]]`link:#quarkus-minio_quarkus-minio-named-minio-clients-secure[quarkus.minio."named-minio-clients".secure]`
 
 
 [.description]
@@ -325,120 +433,12 @@ An optional boolean to enable secure connection.
 Defaults to `true`
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MINIOS_RUNTIME_MINIO_SECURE+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO__NAMED_MINIO_CLIENTS__SECURE+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MINIOS_RUNTIME_MINIO_SECURE+++`
+Environment variable: `+++QUARKUS_MINIO__NAMED_MINIO_CLIENTS__SECURE+++`
 endif::add-copy-button-to-env-var[]
 --|boolean 
-|`false`
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minios-runtime-named-minio-clients-named-minio-clients-url]]`link:#quarkus-minio_quarkus-minios-runtime-named-minio-clients-named-minio-clients-url[quarkus.minios-runtime.named-minio-clients."named-minio-clients".url]`
-
-
-[.description]
---
-The minio server URL.
-The url _may_ contains the port, though it's not recommended. If a specific port is needed, `quakus.minio.port` is a
-better fit.
-<p>
-[NOTE]
-====
-Value must start with `http://` or `https://`
-====
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MINIOS_RUNTIME_NAMED_MINIO_CLIENTS__NAMED_MINIO_CLIENTS__URL+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MINIOS_RUNTIME_NAMED_MINIO_CLIENTS__NAMED_MINIO_CLIENTS__URL+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minios-runtime-named-minio-clients-named-minio-clients-access-key]]`link:#quarkus-minio_quarkus-minios-runtime-named-minio-clients-named-minio-clients-access-key[quarkus.minios-runtime.named-minio-clients."named-minio-clients".access-key]`
-
-
-[.description]
---
-The minio server access key
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MINIOS_RUNTIME_NAMED_MINIO_CLIENTS__NAMED_MINIO_CLIENTS__ACCESS_KEY+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MINIOS_RUNTIME_NAMED_MINIO_CLIENTS__NAMED_MINIO_CLIENTS__ACCESS_KEY+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minios-runtime-named-minio-clients-named-minio-clients-secret-key]]`link:#quarkus-minio_quarkus-minios-runtime-named-minio-clients-named-minio-clients-secret-key[quarkus.minios-runtime.named-minio-clients."named-minio-clients".secret-key]`
-
-
-[.description]
---
-The minio server secret key
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MINIOS_RUNTIME_NAMED_MINIO_CLIENTS__NAMED_MINIO_CLIENTS__SECRET_KEY+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MINIOS_RUNTIME_NAMED_MINIO_CLIENTS__NAMED_MINIO_CLIENTS__SECRET_KEY+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minios-runtime-named-minio-clients-named-minio-clients-region]]`link:#quarkus-minio_quarkus-minios-runtime-named-minio-clients-named-minio-clients-region[quarkus.minios-runtime.named-minio-clients."named-minio-clients".region]`
-
-
-[.description]
---
-An optional bucket region
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MINIOS_RUNTIME_NAMED_MINIO_CLIENTS__NAMED_MINIO_CLIENTS__REGION+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MINIOS_RUNTIME_NAMED_MINIO_CLIENTS__NAMED_MINIO_CLIENTS__REGION+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minios-runtime-named-minio-clients-named-minio-clients-port]]`link:#quarkus-minio_quarkus-minios-runtime-named-minio-clients-named-minio-clients-port[quarkus.minios-runtime.named-minio-clients."named-minio-clients".port]`
-
-
-[.description]
---
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MINIOS_RUNTIME_NAMED_MINIO_CLIENTS__NAMED_MINIO_CLIENTS__PORT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MINIOS_RUNTIME_NAMED_MINIO_CLIENTS__NAMED_MINIO_CLIENTS__PORT+++`
-endif::add-copy-button-to-env-var[]
---|int 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minios-runtime-named-minio-clients-named-minio-clients-secure]]`link:#quarkus-minio_quarkus-minios-runtime-named-minio-clients-named-minio-clients-secure[quarkus.minios-runtime.named-minio-clients."named-minio-clients".secure]`
-
-
-[.description]
---
-An optional boolean to enable secure connection.
-Defaults to `true`
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MINIOS_RUNTIME_NAMED_MINIO_CLIENTS__NAMED_MINIO_CLIENTS__SECURE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MINIOS_RUNTIME_NAMED_MINIO_CLIENTS__NAMED_MINIO_CLIENTS__SECURE+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|`false`
+|`true`
 
 |===

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -64,11 +64,51 @@ public class SampleService {
                 GetObjectArgs.builder()
                         .bucket(bucketName)
                         .object(objectName)
-                        .build());
+                        .build())
         ) {
            // Do whatever you want...
         } catch (MinioException e) {
             throw new IllegalStateException(e);
+        }
+    }
+
+}
+----
+
+=== Async Minio Client
+
+In addition to the blocking `MinioClient` the extension also provides `io.minio.MinioAsyncClient` beans with no extra
+configuration effort.
+
+Just specify `MinioAsyncClient` in place of `MinioClient` and you're good to go.
+
+[source,java]
+----
+package com.acme.minio;
+
+import io.minio.MinioAsyncClient;
+
+// ...
+
+@ApplicationScoped
+public class SampleService {
+
+    @Inject
+    MinioAsyncClient minioClient;
+
+    // ...
+
+    public String getObject(String name) {
+        try (InputStream is = minio.getObject(
+                GetObjectArgs.builder()
+                        .bucket(bucketName)
+                        .object(objectName)
+                        .build())
+                        .get() // Waits for the result in a blocking fashion
+        ) {
+           // Do whatever you want...
+        } catch (MinioException e) {
+            // ...
         }
     }
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
+            <artifactId>quarkus-rest</artifactId>
         </dependency>
 
         <dependency>

--- a/integration-tests/src/main/java/io/quarkiverse/minio/client/AsyncMinioController.java
+++ b/integration-tests/src/main/java/io/quarkiverse/minio/client/AsyncMinioController.java
@@ -1,0 +1,33 @@
+package io.quarkiverse.minio.client;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+
+import io.minio.BucketExistsArgs;
+import io.minio.MinioAsyncClient;
+import io.minio.errors.InsufficientDataException;
+import io.minio.errors.InternalException;
+import io.minio.errors.XmlParserException;
+import io.smallrye.mutiny.Uni;
+
+@Path("/async-minio")
+public class AsyncMinioController {
+    @Inject
+    MinioAsyncClient minioAsyncClient;
+
+    @GET
+    public Uni<String> getBucketExists(@QueryParam("name") String bucketName) throws InsufficientDataException, IOException,
+            NoSuchAlgorithmException, InvalidKeyException, XmlParserException, InternalException {
+        return Uni
+                .createFrom()
+                .completionStage(
+                        minioAsyncClient.bucketExists(BucketExistsArgs.builder().bucket(bucketName).build()))
+                .map(result -> result ? "Bucket exists" : "Bucket doesn't exist");
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/minio/client/MinioClientTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/minio/client/MinioClientTest.java
@@ -41,4 +41,14 @@ public class MinioClientTest {
                 .body(CoreMatchers.containsString("minio_another_client_seconds"));
     }
 
+    @Test
+    public void testInsertAsync() {
+        String response = given()
+                .when().get("/async-minio?name=dummy-bucket")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        assertThat(response).isEqualTo("Bucket doesn't exist");
+    }
 }

--- a/minio-client/runtime/src/main/java/io/quarkiverse/minio/client/MinioClients.java
+++ b/minio-client/runtime/src/main/java/io/quarkiverse/minio/client/MinioClients.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 
 import jakarta.inject.Singleton;
 
+import io.minio.MinioAsyncClient;
 import io.minio.MinioClient;
 import io.minio.http.HttpUtils;
 import io.quarkus.arc.Arc;
@@ -19,6 +20,8 @@ public class MinioClients {
     private final MiniosRuntimeConfiguration miniosRuntimeConfiguration;
 
     private final ConcurrentMap<String, MinioClient> minioClients = new ConcurrentHashMap<>();
+
+    private final ConcurrentMap<String, MinioAsyncClient> minioAsyncClients = new ConcurrentHashMap<>();
 
     private final OptionalHttpClientProducer httpClientProducer;
 
@@ -49,24 +52,33 @@ public class MinioClients {
                 .getMinioClient(minioClientName);
     }
 
+    /**
+     * Meant to be used from recorders that create synthetic beans that need access to {@code MinioAsyncClient}.
+     * In such using {@code Arc.container.instance(MinioAsyncClient.class)} is not possible because
+     * {@code MinioAsyncClient} is itself a synthetic bean.
+     * <p>
+     * This method relies on the fact that {@code MinioClients} should - given the same input -
+     * always return the same {@code MinioAsyncClient} no matter how many times it is invoked
+     * (which makes sense because {@code MinioAsyncClient} is a {@code Singleton} bean).
+     * <p>
+     * This method is thread-safe
+     */
+    public static MinioAsyncClient fromNameAsync(String minioClientName) {
+        return Arc.container().instance(MinioClients.class).get()
+                .getMinioAsyncClient(minioClientName);
+    }
+
     public MinioClient getMinioClient(String minioClientName) {
         return minioClients.computeIfAbsent(minioClientName, this::createMinioClient);
     }
 
+    public MinioAsyncClient getMinioAsyncClient(String minioClientName) {
+        return minioAsyncClients.computeIfAbsent(minioClientName, this::createMinioAsyncClient);
+    }
+
     public MinioClient createMinioClient(String minioClientName) {
-        if (!miniosBuildTimeConfiguration.getMinioClients().containsKey(minioClientName)) {
-            throw new IllegalArgumentException("No Minioclient named '" + minioClientName + "' exists");
-        }
-        MinioRuntimeConfiguration configuration = getConfiguration(minioClientName);
-        if (IS_URL_SET.test(configuration.getUrl())) {
-            String errorMessage;
-            if (MiniosBuildTimeConfiguration.isDefault(minioClientName)) {
-                errorMessage = "\"quarkus.minio.url\" is mandatory and must be a valid url";
-            } else {
-                errorMessage = "\"quarkus.minio." + minioClientName + ".url\" is mandatory and must be a valid url";
-            }
-            throw new ConfigurationException(errorMessage);
-        }
+        MinioRuntimeConfiguration configuration = getAndVerifyConfiguration(minioClientName);
+
         MinioClient.Builder builder = MinioClient.builder();
         configuration.getPort()
                 .ifPresentOrElse(
@@ -83,11 +95,48 @@ public class MinioClients {
         return builder.build();
     }
 
-    private MinioRuntimeConfiguration getConfiguration(String minioClientName) {
-        if (MiniosBuildTimeConfiguration.isDefault(minioClientName)) {
-            return miniosRuntimeConfiguration.minio();
+    public MinioAsyncClient createMinioAsyncClient(String minioClientName) {
+        MinioRuntimeConfiguration configuration = getAndVerifyConfiguration(minioClientName);
+
+        MinioAsyncClient.Builder builder = MinioAsyncClient.builder();
+        configuration.getPort()
+                .ifPresentOrElse(
+                        port -> builder.endpoint(configuration.getUrl(), port, configuration.isTls()),
+                        () -> builder.endpoint(
+                                HttpUtils.getBaseUrl(configuration.getUrl()).newBuilder()
+                                        .scheme(configuration.isTls() ? "https" : "http").build()));
+
+        builder.credentials(configuration.getAccessKey(), configuration.getSecretKey());
+        configuration.region.ifPresent(builder::region);
+        if (miniosRuntimeConfiguration.produceMetrics) {
+            httpClientProducer.apply(minioClientName).ifPresent(builder::httpClient);
         }
-        return miniosRuntimeConfiguration.namedMinioClients().getOrDefault(minioClientName,
-                new MinioRuntimeConfiguration());
+        return builder.build();
+    }
+
+    private MinioRuntimeConfiguration getAndVerifyConfiguration(String minioClientName) {
+        if (!miniosBuildTimeConfiguration.getMinioClients().containsKey(minioClientName)) {
+            throw new IllegalArgumentException("No Minioclient named '" + minioClientName + "' exists");
+        }
+
+        MinioRuntimeConfiguration configuration;
+        if (MiniosBuildTimeConfiguration.isDefault(minioClientName)) {
+            configuration = miniosRuntimeConfiguration.minio();
+        } else {
+            configuration = miniosRuntimeConfiguration.namedMinioClients().getOrDefault(minioClientName,
+                    new MinioRuntimeConfiguration());
+        }
+
+        if (IS_URL_SET.test(configuration.getUrl())) {
+            String errorMessage;
+            if (MiniosBuildTimeConfiguration.isDefault(minioClientName)) {
+                errorMessage = "\"quarkus.minio.url\" is mandatory and must be a valid url";
+            } else {
+                errorMessage = "\"quarkus.minio." + minioClientName + ".url\" is mandatory and must be a valid url";
+            }
+            throw new ConfigurationException(errorMessage);
+        }
+
+        return configuration;
     }
 }

--- a/minio-client/runtime/src/main/java/io/quarkiverse/minio/client/MinioRecorder.java
+++ b/minio-client/runtime/src/main/java/io/quarkiverse/minio/client/MinioRecorder.java
@@ -2,6 +2,7 @@ package io.quarkiverse.minio.client;
 
 import java.util.function.Supplier;
 
+import io.minio.MinioAsyncClient;
 import io.minio.MinioClient;
 import io.quarkus.runtime.annotations.Recorder;
 
@@ -11,5 +12,10 @@ public class MinioRecorder {
     public Supplier<MinioClient> minioClientSupplier(String minioClientName,
             @SuppressWarnings("unused") MiniosRuntimeConfiguration minioRuntimeConfig) {
         return () -> MinioClients.fromName(minioClientName);
+    }
+
+    public Supplier<MinioAsyncClient> minioAsyncClientSupplier(String minioClientName,
+            @SuppressWarnings("unused") MiniosRuntimeConfiguration minioRuntimeConfig) {
+        return () -> MinioClients.fromNameAsync(minioClientName);
     }
 }


### PR DESCRIPTION
Now this extension also provides `MinioAsyncClient` beans in addition to the usual `MinioClient` beans.

I've added also a simple integration test that uses a `MinioAsyncClient`. It's kinda clunky but that's to be expected when doing reactive stuff.

Also, `quarkus-minio.adoc` was updated, please check if that is ok, I'm not sure.

Closes #328