### PR TITLE
Add configuration option to enable testcontainer reuse

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-minio.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-minio.adoc
@@ -97,6 +97,29 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`true`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minio-devservices-reuse-enabled]] [.property-path]##link:#quarkus-minio_quarkus-minio-devservices-reuse-enabled[`quarkus.minio.devservices.reuse-enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.minio.devservices.reuse-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to keep Dev Service containers running after a dev mode session or test suite execution to reuse them in the next dev mode session.
+
+Enabled by default
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO_DEVSERVICES_REUSE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MINIO_DEVSERVICES_REUSE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minio-devservices-service-name]] [.property-path]##link:#quarkus-minio_quarkus-minio-devservices-service-name[`quarkus.minio.devservices.service-name`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.minio.devservices.service-name+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-minio_quarkus.minio.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-minio_quarkus.minio.adoc
@@ -97,6 +97,29 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`true`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minio-devservices-reuse-enabled]] [.property-path]##link:#quarkus-minio_quarkus-minio-devservices-reuse-enabled[`quarkus.minio.devservices.reuse-enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.minio.devservices.reuse-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to keep Dev Service containers running after a dev mode session or test suite execution to reuse them in the next dev mode session.
+
+Enabled by default
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MINIO_DEVSERVICES_REUSE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MINIO_DEVSERVICES_REUSE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minio-devservices-service-name]] [.property-path]##link:#quarkus-minio_quarkus-minio-devservices-service-name[`quarkus.minio.devservices.service-name`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.minio.devservices.service-name+++[]

--- a/minio-client/deployment/src/main/java/io/quarkiverse/minio/client/deployment/devservices/DevServicesMinioProcessor.java
+++ b/minio-client/deployment/src/main/java/io/quarkiverse/minio/client/deployment/devservices/DevServicesMinioProcessor.java
@@ -213,7 +213,7 @@ public class DevServicesMinioProcessor {
 
             timeout.ifPresent(container::withStartupTimeout);
 
-            container.withReuse(true);
+            container.withReuse(config.reuseEnabled);
 
             container.start();
 
@@ -299,6 +299,7 @@ public class DevServicesMinioProcessor {
         private final String imageName;
         private final Integer fixedExposedPort;
         private final boolean shared;
+        private final boolean reuseEnabled;
         private final String serviceName;
         private final String accessKey;
         private final String secretKey;
@@ -309,6 +310,7 @@ public class DevServicesMinioProcessor {
             this.imageName = config.imageName();
             this.fixedExposedPort = config.port();
             this.shared = config.shared();
+            this.reuseEnabled = config.reuseEnabled();
             this.serviceName = config.serviceName();
             this.accessKey = config.accessKey();
             this.secretKey = config.secretKey();

--- a/minio-client/deployment/src/main/java/io/quarkiverse/minio/client/deployment/devservices/MinioDevServicesBuildTimeConfig.java
+++ b/minio-client/deployment/src/main/java/io/quarkiverse/minio/client/deployment/devservices/MinioDevServicesBuildTimeConfig.java
@@ -45,6 +45,15 @@ public interface MinioDevServicesBuildTimeConfig {
     boolean shared();
 
     /**
+     * Whether to keep Dev Service containers running after a dev mode session or test
+     * suite execution to reuse them in the next dev mode session.
+     * <p>
+     * Enabled by default
+     */
+    @WithDefault("true")
+    boolean reuseEnabled();
+
+    /**
      * The value of the {@code quarkus-dev-service-minio} label attached to the started container.
      * This property is used when {@code shared} is set to {@code true}.
      * In this case, before starting a container, Dev Services for Minio looks for a container with the


### PR DESCRIPTION
This pull request introduces a new feature to the Quarkus Minio Dev Services configuration, allowing Dev Service containers to be reused between dev mode sessions or test suite executions.

Parking this PR here to get some feedback as I'm pretty unsure how this works. First time working in a quarkus extension.

I've not been able to test this code properly, since I'm running into `classdefnotfound` errors when importing this dependency after `mvn install` locally, I have verified the dep is installed in my `.m2` folder.