### PR TITLE
Upgrade MinIO dev service to newest version

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-minio.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-minio.adoc
@@ -70,7 +70,7 @@ Environment variable: `+++QUARKUS_MINIO_DEVSERVICES_IMAGE_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`minio/minio:RELEASE.2022-10-08T20-11-00Z`
+|`minio/minio:RELEASE.2025-04-22T22-12-26Z`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minio-devservices-shared]] [.property-path]##link:#quarkus-minio_quarkus-minio-devservices-shared[`quarkus.minio.devservices.shared`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-minio_quarkus.minio.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-minio_quarkus.minio.adoc
@@ -70,7 +70,7 @@ Environment variable: `+++QUARKUS_MINIO_DEVSERVICES_IMAGE_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`minio/minio:RELEASE.2022-10-08T20-11-00Z`
+|`minio/minio:RELEASE.2025-04-22T22-12-26Z`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-minio_quarkus-minio-devservices-shared]] [.property-path]##link:#quarkus-minio_quarkus-minio-devservices-shared[`quarkus.minio.devservices.shared`]##
 ifdef::add-copy-button-to-config-props[]

--- a/minio-client/deployment/src/main/java/io/quarkiverse/minio/client/deployment/devservices/MinioDevServicesBuildTimeConfig.java
+++ b/minio-client/deployment/src/main/java/io/quarkiverse/minio/client/deployment/devservices/MinioDevServicesBuildTimeConfig.java
@@ -27,7 +27,7 @@ public interface MinioDevServicesBuildTimeConfig {
     /**
      * The Minio container image to use.
      */
-    @WithDefault("minio/minio:RELEASE.2022-10-08T20-11-00Z")
+    @WithDefault("minio/minio:RELEASE.2025-04-22T22-12-26Z")
     String imageName();
 
     /**


### PR DESCRIPTION
The current default MinIO dev service version is quite outdated, so I thought I'd propose a PR to upgrade it to the newest version.